### PR TITLE
排除語音序列 beep 被誤美化為進度條音效

### DIFF
--- a/source code/globalPlugins/pleasant progress.py
+++ b/source code/globalPlugins/pleasant progress.py
@@ -1104,8 +1104,14 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
             self.original_beep = None
             print("悅耳進度條：已恢復原始tones.beep函數")
     
-    def optimized_beep(self, hz, length, left=50, right=50):
-        """接管 tones.beep：識別進度條音效並改用悅耳波形，其它音效照原樣播放"""
+    def optimized_beep(self, hz, length, left=50, right=50, **kwargs):
+        """接管 tones.beep：識別進度條音效並改用悅耳波形，其它音效照原樣播放
+
+        以 **kwargs 接收並原樣轉發新版 NVDA 經 tones.beep 帶入的關鍵字參數（例如
+        語音序列 BeepCommand 的 isSpeechBeepCommand，用於大寫字母、行縮排提示音等）。
+        若不接收這些參數，凡是帶關鍵字參數的原始提示音都會在此無聲；舊版 NVDA 的
+        tones.beep 不會傳這些參數，因此 kwargs 為空也相容。
+        """
         # 檢查是否為進度條音效
         if self.is_progress_beep(hz, length, left, right):
             if self.debug_mode:
@@ -1122,7 +1128,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
         
         # 播放原始音效（進度條音效且插件停用時，或者非進度條音效時）
         if self.original_beep:
-            self.original_beep(hz, length, left, right)
+            self.original_beep(hz, length, left, right, **kwargs)
 
     def old_generate_clean_sine_wave_32bit(self, frequency, duration=0.08, sample_rate=44100, volume=0.6):
         """純Python生成乾淨的正弦波音效 - 32位優化版本（余弦淡入淡出）"""

--- a/source code/globalPlugins/pleasant progress.py
+++ b/source code/globalPlugins/pleasant progress.py
@@ -1112,8 +1112,8 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
         若不接收這些參數，凡是帶關鍵字參數的原始提示音都會在此無聲；舊版 NVDA 的
         tones.beep 不會傳這些參數，因此 kwargs 為空也相容。
         """
-        # 檢查是否為進度條音效
-        if self.is_progress_beep(hz, length, left, right):
+        # 檢查是否為進度條音效（語音序列 beep 會經 isSpeechBeepCommand 被排除）
+        if self.is_progress_beep(hz, length, left, right, **kwargs):
             if self.debug_mode:
                 print(f"悅耳進度條：識別為進度條音效: {hz}Hz")
             
@@ -1369,8 +1369,16 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
             else:
                 return sample
 
-    def is_progress_beep(self, hz, length, left, right):
-        """檢查是否為進度條音效"""
+    def is_progress_beep(self, hz, length, left, right, **kwargs):
+        """檢查是否為進度條音效
+
+        語音序列 BeepCommand（大寫字母、行縮排提示音等）會帶 isSpeechBeepCommand=True，
+        其頻率/長度可能落在下列範圍內而被誤判為進度條。這類音效應跟著語音時機由原始
+        tones.beep 播放，故直接排除。此旗標自 NVDA 2023.1 (#14503) 起才有；舊版 NVDA
+        不會傳入，kwargs 為空時不影響判定，維持既有行為（向下相容）。
+        """
+        if kwargs.get("isSpeechBeepCommand"):
+            return False
         return (
             110 <= hz <= 1800 and
             38 <= length <= 42 and


### PR DESCRIPTION
行縮排提示音的頻率/長度落在進度條判定範圍內，被 `is_progress_beep` 誤判而改播悅耳波形。於 `is_progress_beep` 以 `isSpeechBeepCommand` 排除語音序列 `BeepCommand`（行縮排、大寫字母等），交回原始 `tones.beep` 依語音時機播放。

本 PR 疊在 #3 上，diff 含 #3 的 commit（縮排修正用到其於 `optimized_beep` 加入的 `**kwargs`）。#3 先 merge 的話，此 PR 會自動只剩縮排這個 commit。

🤖 Generated with [Claude Code](https://claude.com/claude-code)